### PR TITLE
feat: updated dependencies for extended packages

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,5 +29,20 @@
     "eslint-plugin-unicorn": "^29.0.0",
     "eslint-plugin-vue": "^7.9.0",
     "standard-version": "^9.3.2"
+  },
+  "peerDependencies": {
+    "@typescript-eslint/eslint-plugin": "^3.8.x",
+    "@typescript-eslint/parser": "^3.8.x",
+    "eslint": "^7.0.0 || ^8.0.0",
+    "eslint-config-prettier": "^8.3.x",
+    "eslint-import-resolver-alias": "^1.1.x",
+    "eslint-import-resolver-node": "^0.3.x",
+    "eslint-import-resolver-nuxt": "^1.0.x",
+    "eslint-plugin-import": "^2.22.x",
+    "eslint-plugin-prettier": "^3.4.x",
+    "eslint-plugin-react": "^7.20.x",
+    "eslint-plugin-react-hooks": "^4.1.x",
+    "eslint-plugin-unicorn": "^29.0.x",
+    "eslint-plugin-vue": "^7.9.x"
   }
 }


### PR DESCRIPTION
При установке пакета все плагины, от которых мы делаем extend необходимо ставить самому. Таким образом, если я поставлю только @web-bee/react, то остальные его `prettier, imports` и другие придется ставить самому. Т.к это не депенденси.

**Без peerDeps**:
![image](https://github.com/user-attachments/assets/9e247dba-d6b7-4a36-ae3e-8e8c758b3777)
**С peerDeps**:
![image](https://github.com/user-attachments/assets/88c59349-7eab-49cc-bb26-0c929529700c)
Плагин есть в базовом конфиге:
![image](https://github.com/user-attachments/assets/968d0c00-25f2-4897-91ee-edb82a16c0ad)

