### PR TITLE
feat(DEVTASKS-67): конфиг обновлён под 9 версию eslint

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,6 @@
 .idea
 .vscode/
+.tsup
 /node_modules
 package-lock.json
+/dist

--- a/README.md
+++ b/README.md
@@ -1,48 +1,85 @@
 # @web-bee-ru/eslint-plugin
 
 ## Install
+
+### Base config
+
 ``` bash
 $ npm i --save-dev @web-bee-ru/eslint-plugin
 ```
 
-### devDependencies
-
-- @typescript-eslint/eslint-plugin
-- @typescript-eslint/parser
-- eslint
-- eslint-config-prettier
-- eslint-import-resolver-alias
-- eslint-import-resolver-node
-- eslint-import-resolver-nuxt
-- eslint-plugin-import
-- eslint-plugin-prettier
-- eslint-plugin-react
-- eslint-plugin-react-hooks
-- eslint-plugin-vue
+### React config
 
 ``` bash
-# install base devDependencies
-$ npm i --save-dev eslint @typescript-eslint/eslint-plugin @typescript-eslint/parser eslint-config-prettier eslint-import-resolver-alias eslint-import-resolver-node eslint-plugin-import eslint-plugin-prettier
+$ npm i --save-dev @web-bee-ru/eslint-plugin eslint-plugin-react eslint-plugin-react-hooks
+```
+
+### Next config
+
+``` bash
+$ npm i --save-dev @web-bee-ru/eslint-plugin eslint-plugin-react eslint-plugin-react-hooks
+```
+
+### Vue config
+
+``` bash
+$ npm i --save-dev @web-bee-ru/eslint-plugin eslint-plugin-vue
+```
+
+### Nuxt config
+
+``` bash
+$ npm i --save-dev @web-bee-ru/eslint-plugin eslint-plugin-vue eslint-import-resolver-nuxt
 ```
 
 ## Using
 
-Available configs:
+### Available configs:
 
 ``` js
-extends: [
-    "plugin:@web-bee-ru/base", // js/ts only
+// esm
+import base from "@web-bee-ru/eslint-plugin"
+import react from "@web-bee-ru/eslint-plugin/react"
+import next from "@web-bee-ru/eslint-plugin/next"
+import vue from "@web-bee-ru/eslint-plugin/vue"
+import nuxt from "@web-bee-ru/eslint-plugin/nuxt"
 
-    // npm i --save-dev eslint-plugin-vue
-    "plugin:@web-bee-ru/vue", // vue
-
-    // npm i --save-dev eslint-plugin-vue eslint-import-resolver-nuxt
-    "plugin:@web-bee-ru/nuxt", // nuxt (vue)
-
-    // npm i --save-dev eslint-plugin-react eslint-plugin-react-hooks
-    "plugin:@web-bee-ru/react", // react
-
-    // npm i --save-dev eslint-plugin-react eslint-plugin-react-hooks
-    "plugin:@web-bee-ru/next", // next (react)
-],
+// commonjs
+const base = require("@web-bee-ru/eslint-plugin")
+const react = require("@web-bee-ru/eslint-plugin/react")
+const next = require("@web-bee-ru/eslint-plugin/next")
+const vue = require("@web-bee-ru/eslint-plugin/vue")
+const nuxt = require("@web-bee-ru/eslint-plugin/nuxt")
 ```
+
+### In your eslint.config.js
+
+```js
+import { defineConfig } from "eslint/config";
+import base from "@web-bee-ru/eslint-plugin"
+
+export defineConfig([
+ ...base,
+ // Or 
+ {
+   extends: {
+      base,
+   }
+ }
+]);
+```
+
+### peerDependencies
+
+- @stylistic/eslint-plugin
+- typescript-eslint
+- eslint
+- eslint-config-prettier
+- eslint-import-resolver-alias
+- eslint-import-resolver-node
+- eslint-import-resolver-nuxt [ optional ]
+- eslint-plugin-import
+- eslint-plugin-prettier
+- eslint-plugin-react [ optional ]
+- eslint-plugin-react-hooks [ optional ]
+- eslint-plugin-vue [ optional ]

--- a/configs/base.js
+++ b/configs/base.js
@@ -79,7 +79,9 @@ export default defineConfig([
       }],
       '@stylistic/no-trailing-spaces': ['error'],
       '@stylistic/quote-props': ['error', 'consistent-as-needed'],
-      '@stylistic/quotes': ['error', 'single'],
+      '@stylistic/quotes': ['error', 'single', {
+        avoidEscape: true,
+      }],
       '@stylistic/semi': ['error', 'always'],
     },
   }

--- a/configs/base.js
+++ b/configs/base.js
@@ -1,12 +1,12 @@
-const { defineConfig } = require('eslint/config');
-const globals = require('globals');
-const eslint = require('@eslint/js');
-const tsEslint = require('typescript-eslint');
-const stylistic = require('@stylistic/eslint-plugin');
-const eslintPluginPrettierRecommended = require('eslint-plugin-prettier/recommended');
-const importPlugin = require('eslint-plugin-import');
+import { defineConfig } from 'eslint/config';
+import globals from 'globals';
+import eslint from '@eslint/js';
+import tsEslint from 'typescript-eslint';
+import stylistic from '@stylistic/eslint-plugin';
+import eslintPluginPrettierRecommended from 'eslint-plugin-prettier/recommended';
+import importPlugin from 'eslint-plugin-import';
 
-module.exports = defineConfig([
+export default defineConfig([
   {
     languageOptions: {
       ecmaVersion: 2020,

--- a/configs/base.js
+++ b/configs/base.js
@@ -1,96 +1,86 @@
-module.exports = {
-  env: {
-    browser: true,
-    node: true,
-    es2020: true,
-  },
-  parser: '@typescript-eslint/parser',
-  parserOptions: {
-    ecmaVersion: 2020,
-    sourceType: 'module',
-    ecmaFeatures: {
-      jsx: true,
-    },
-  },
-  plugins: ['@typescript-eslint/eslint-plugin', 'prettier'],
-  extends: [
-    'eslint:recommended',
-    'plugin:@typescript-eslint/recommended',
-    'plugin:import/errors',
-    'plugin:import/warnings',
-    'plugin:import/typescript',
-    'prettier',
-  ],
-  settings: {
-    'import/resolver': {
-      alias: {
-        map: [['~', './src/']],
-        extensions: ['.ts', '.js'],
+const { defineConfig } = require('eslint/config');
+const globals = require('globals');
+const eslint = require('@eslint/js');
+const tsEslint = require('typescript-eslint');
+const stylistic = require('@stylistic/eslint-plugin');
+const eslintPluginPrettierRecommended = require('eslint-plugin-prettier/recommended');
+const importPlugin = require('eslint-plugin-import');
+
+module.exports = defineConfig([
+  {
+    languageOptions: {
+      ecmaVersion: 2020,
+      sourceType: 'module',
+      globals: {
+        ...globals.browser,
+        ...globals.node,
+        ...globals.es2020,
+      },
+      parser: tsEslint.parser,
+      parserOptions: {
+        ecmaFeatures: {
+          jsx: true,
+        },
       },
     },
-  },
-  rules: {
-    'quotes': ['error', 'single'],
-
-    'object-curly-newline': ['off'], // не понял глубокого смысла этого правила...
-    'prefer-destructuring': ['off'], // сложно искать работу с частями ДТОшек
-    'global-require': ['off'], // не актуально для вебпака
-    'quote-props': ['error', 'consistent-as-needed'],
-    'no-plusplus': ['off'], // потому что WTF?!
-    'arrow-body-style': ['off'], // проще ставить бряки если есть скобочки, пусть они и не нужны
-    'consistent-return': ['off'], // функции не всегда возвращают значение
-    'no-param-reassign': ['error', { props: false }], // потому что reduce
-    'no-useless-return': ['off'], // потому что идите в жопу. Пишу как хочу, из-за этого не сломается
-    'arrow-parens': ['off'], // зачем оборачивать то, что не нужно?
-    'eqeqeq': ['warn', 'always', { null: 'ignore' }], // в airbnb был error
-    'space-before-function-paren': ['off'], // конфликтует с prettier
-    'func-names': ['error', 'never'], // зачем давать имена анонимным функциям? о_О
-
-    'linebreak-style': ['off'],
-    'no-trailing-spaces': ['error'],
-    'eol-last': ['error'],
-
-    'no-console': ['error', { allow: ['warn', 'error', 'info'] }], // варны и эрроры и инфо - ок
-
-    'no-debugger': ['error'],
-    'no-unused-vars': ['warn', { args: 'none' }], // просто переменные - error, аргументы в методе - норм.
-
-    'prefer-const': ['off'],
-    'max-len': ['off'],
-    'space-infix-ops': ['off'],
-    'import/extensions': ['off'],
-    'import/no-unresolved': ['off'],
-    'no-restricted-syntax': ['off'],
-    'no-else-return': ['off'],
-    'no-lonely-if': ['off'],
-
-    'semi': ['off'],
-    'comma-dangle': ['error', 'always-multiline'],
-    'brace-style': ['off', 'stroustrup', { allowSingleLine: true }],
-
-    // @NOTE: TS
-    '@typescript-eslint/semi': ['error', 'always'],
-    '@typescript-eslint/member-delimiter-style': ['error', {
-      multiline: {
-        delimiter: 'semi',
-        requireLast: true,
+    plugins: {
+      '@typescript-eslint': tsEslint.plugin,
+      '@stylistic': stylistic,
+    },
+    extends: [
+      eslint.configs.recommended,
+      tsEslint.configs.recommended,
+      importPlugin.flatConfigs.errors,
+      importPlugin.flatConfigs.warnings,
+      importPlugin.flatConfigs.typescript,
+      eslintPluginPrettierRecommended,
+    ],
+    settings: {
+      "import/resolver": {
+        alias: {
+          map: [['~', './src/']],
+          extensions: ['.ts', '.js'],
+        },
       },
-      singleline: {
-        delimiter: 'semi',
-        requireLast: false,
-      },
-    }],
+    },
+    rules: {
+      'no-param-reassign': ['error', { props: false }], // потому что reduce
+      'eqeqeq': ['warn', 'always', { null: 'ignore' }], // в airbnb был error
+      'func-names': ['error', 'never'], // зачем давать имена анонимным функциям? о_О
 
-    // @NOTE: Too TS
-    '@typescript-eslint/ban-types': ['off'], // @TODO: Disable only baning {}
-    '@typescript-eslint/no-namespace': ['off'],
-    '@typescript-eslint/ban-ts-comment': ['off'],
+      'no-console': ['error', { allow: ['warn', 'error', 'info'] }], // варны и эрроры и инфо - ок
 
-    // @NOTE: imports
-    'import/prefer-default-export': ['off'],
-    'import/no-cycle': ['warn'],
-    'import/namespace': ['off'],
-  },
-  overrides: [
-  ],
-};
+      'no-debugger': ['error'],
+      'no-unused-vars': ['warn', { args: 'none' }], // просто переменные - error, аргументы в методе - норм.
+
+      'prefer-const': ['off'],
+      'import/no-unresolved': ['off'],
+
+      // @NOTE: Too TS
+      '@typescript-eslint/no-empty-object-type': ['off'],
+      '@typescript-eslint/no-namespace': ['off'],
+      '@typescript-eslint/ban-ts-comment': ['off'],
+
+      // @NOTE: imports
+      'import/no-cycle': ['warn'],
+      'import/namespace': ['off'],
+
+      '@stylistic/comma-dangle': ['error', 'always-multiline'],
+      '@stylistic/eol-last': ['error'],
+      '@stylistic/member-delimiter-style': ['error', {
+        multiline: {
+          delimiter: 'semi',
+          requireLast: true,
+        },
+        singleline: {
+          delimiter: 'semi',
+          requireLast: false,
+        },
+      }],
+      '@stylistic/no-trailing-spaces': ['error'],
+      '@stylistic/quote-props': ['error', 'consistent-as-needed'],
+      '@stylistic/quotes': ['error', 'single'],
+      '@stylistic/semi': ['error', 'always'],
+    },
+  }
+])

--- a/configs/next.js
+++ b/configs/next.js
@@ -1,7 +1,7 @@
-const { defineConfig } = require('eslint/config');
-const react = require('./react');
+import { defineConfig } from 'eslint/config';
+import react from './react';
 
-module.exports = defineConfig([
+export default defineConfig([
   {
     extends: [react],
   },

--- a/configs/next.js
+++ b/configs/next.js
@@ -1,5 +1,8 @@
-module.exports = {
-  extends: [
-    require.resolve('./react'),
-  ]
-};
+const { defineConfig } = require('eslint/config');
+const react = require('./react');
+
+module.exports = defineConfig([
+  {
+    extends: [react],
+  },
+]);

--- a/configs/nuxt.js
+++ b/configs/nuxt.js
@@ -1,10 +1,11 @@
-module.exports = {
-  extends: [
-    require.resolve('./vue'),
-  ],
-  settings: {
-    'import/resolver': 'nuxt',
+const { defineConfig } = require('eslint/config');
+const vue = require('./vue');
+
+module.exports = defineConfig([
+  {
+    extends: [vue],
+    settings: {
+      'import/resolver': 'nuxt',
+    },
   },
-  overrides: [
-  ]
-};
+]);

--- a/configs/nuxt.js
+++ b/configs/nuxt.js
@@ -1,7 +1,7 @@
-const { defineConfig } = require('eslint/config');
-const vue = require('./vue');
+import { defineConfig } from 'eslint/config';
+import vue from './vue';
 
-module.exports = defineConfig([
+export default defineConfig([
   {
     extends: [vue],
     settings: {

--- a/configs/react.js
+++ b/configs/react.js
@@ -1,9 +1,9 @@
-const { defineConfig } = require('eslint/config');
-const base = require('./base');
-const reactPlugin = require('eslint-plugin-react');
-const reactHooksPlugin = require('eslint-plugin-react-hooks');
+import { defineConfig } from 'eslint/config';
+import base from './base';
+import reactPlugin from 'eslint-plugin-react';
+import reactHooksPlugin from 'eslint-plugin-react-hooks';
 
-module.exports = defineConfig([
+export default defineConfig([
   {
     plugins: {
       'react': reactPlugin,

--- a/configs/react.js
+++ b/configs/react.js
@@ -1,25 +1,32 @@
-module.exports = {
-  extends: [
-    require.resolve('./base'),
-    'plugin:react/recommended',
-    'plugin:react-hooks/recommended',
-  ],
-  plugins: [
-    'react',
-  ],
-  settings: {
-    'import/resolver': {
-      alias: {
-        map: [['~', './src/']],
-        extensions: ['.ts', '.js', '.tsx', '.jsx'],
+const { defineConfig } = require('eslint/config');
+const base = require('./base');
+const reactPlugin = require('eslint-plugin-react');
+const reactHooksPlugin = require('eslint-plugin-react-hooks');
+
+module.exports = defineConfig([
+  {
+    plugins: {
+      'react': reactPlugin,
+    },
+    extends: [
+      base,
+      reactHooksPlugin.configs['recommended-latest'],
+      reactPlugin.configs.flat['recommended'],
+    ],
+    settings: {
+      'import/resolver': {
+        alias: {
+          map: [['~', './src/']],
+          extensions: ['.ts', '.js', '.tsx', '.jsx'],
+        },
       },
     },
-  },
-  rules: {
-    // @NOTE: We decided against prop validations
-    'react/prop-types': ['off'],
+    rules: {
+      // @NOTE: We decided against prop validations
+      'react/prop-types': ['off'],
 
-    // @NOTE: ОБЯЗАТЕЛЬНО нужно указывать все зависимости
-    'react-hooks/exhaustive-deps': ['error'],
-  },
-};
+      // @NOTE: ОБЯЗАТЕЛЬНО нужно указывать все зависимости
+      'react-hooks/exhaustive-deps': ['error'],
+    },
+  }
+])

--- a/configs/vue.js
+++ b/configs/vue.js
@@ -1,8 +1,8 @@
-const { defineConfig } = require('eslint/config');
-const base = require('./base');
-const vuePlugin = require('eslint-plugin-vue');
+import { defineConfig } from 'eslint/config';
+import base from './base';
+import vuePlugin from 'eslint-plugin-vue';
 
-module.exports = defineConfig([
+export default defineConfig([
   {
     plugins: {
       'vue': vuePlugin,

--- a/configs/vue.js
+++ b/configs/vue.js
@@ -1,39 +1,44 @@
-module.exports = {
-  extends: [
-    require.resolve('./base'),
-    'plugin:vue/strongly-recommended',
-  ],
-  plugins: [
-    'vue'
-  ],
-  settings: {
-    'import/resolver': {
-      alias: {
-        map: [['~', './src/']],
-        extensions: ['.ts', '.js', '.tsx', '.jsx', '.vue'],
-      },
-    },
-  },
-  rules: {
-    'vue/max-attributes-per-line': ['off'],
-    'vue/attribute-hyphenation': ['off'],
-    'vue/html-self-closing': ['off'],
+const { defineConfig } = require('eslint/config');
+const base = require('./base');
+const vuePlugin = require('eslint-plugin-vue');
 
-    'vue/script-indent': ['off'],
-  },
-  overrides: [
-    {
-      files: ['src/**/*.vue'],
-      rules: {
-        'vue/html-indent': ['error', 2, {
-          alignAttributesVertically: false,
-          closeBracket: 1,
-        }],
-        'vue/script-indent': ['error', 2, {
-          baseIndent: 1,
-          switchCase: 1,
-        }],
+module.exports = defineConfig([
+  {
+    plugins: {
+      'vue': vuePlugin,
+    },
+    extends: [
+      base,
+      vuePlugin.configs['flat/strongly-recommended'],
+    ],
+    settings: {
+      'import/resolver': {
+        alias: {
+          map: [['~', './src/']],
+          extensions: ['.ts', '.js', '.tsx', '.jsx', '.vue'],
+        },
       },
     },
-  ],
-};
+    rules: {
+      'vue/max-attributes-per-line': ['off'],
+      'vue/attribute-hyphenation': ['off'],
+      'vue/html-self-closing': ['off'],
+
+      'vue/script-indent': ['off'],
+    },
+  },
+  {
+    files: ['src/**/*.vue'],
+    rules: {
+      'vue/html-indent': ['error', 2, {
+        alignAttributesVertically: false,
+        closeBracket: 1,
+      }],
+      'vue/script-indent': ['error', 2, {
+        baseIndent: 1,
+        switchCase: 1,
+      }],
+    },
+  }
+])
+

--- a/index.js
+++ b/index.js
@@ -1,9 +1,0 @@
-module.exports = {
-  configs: {
-    'base': require('./configs/base'),
-    'vue': require('./configs/vue'),
-    'nuxt': require('./configs/nuxt'),
-    'react': require('./configs/react'),
-    'next': require('./configs/next'),
-  },
-};

--- a/package.json
+++ b/package.json
@@ -2,8 +2,9 @@
   "name": "@web-bee-ru/eslint-plugin",
   "version": "0.6.4",
   "description": "Our eslint config for projects",
-  "main": "index.js",
+  "type": "module",
   "scripts": {
+    "build": "tsup",
     "test": "echo \"Error: no test specified\" && exit 1",
     "release": "standard-version"
   },
@@ -14,6 +15,38 @@
   "homepage": "https://github.com/web-bee-ru/eslint-plugin",
   "author": "dev@web-bee.ru",
   "license": "ISC",
+  "files": [
+    "dist/**/*",
+    "CHANGELOG.md",
+    "README.md"
+  ],
+  "exports": {
+    ".": {
+      "types": "./dist/types/base.d.ts",
+      "import": "./dist/base.js",
+      "require": "./dist/base.cjs"
+    },
+    "./react": {
+      "types": "./dist/types/react.d.ts",
+      "import": "./dist/react.js",
+      "require": "./dist/react.cjs"
+    },
+    "./next": {
+      "types": "./dist/types/next.d.ts",
+      "import": "./dist/next.js",
+      "require": "./dist/next.cjs"
+    },
+    "./vue": {
+      "types": "./dist/types/vue.d.ts",
+      "import": "./dist/vue.js",
+      "require": "./dist/vue.cjs"
+    },
+    "./nuxt": {
+      "types": "./dist/types/nuxt.d.ts",
+      "import": "./dist/nuxt.js",
+      "require": "./dist/nuxt.cjs"
+    }
+  },
   "devDependencies": {
     "@stylistic/eslint-plugin": "^4.2.0",
     "eslint": "^9.25.0",
@@ -26,7 +59,39 @@
     "eslint-plugin-react": "^7.37.5",
     "eslint-plugin-react-hooks": "^5.2.0",
     "eslint-plugin-vue": "^10.0.0",
+    "globals": "^14.0.0",
     "standard-version": "^9.3.2",
+    "tsup": "^8.5.0",
+    "typescript": "^5.8.3",
     "typescript-eslint": "^8.31.1"
+  },
+  "peerDependencies": {
+    "@stylistic/eslint-plugin": ">=4",
+    "eslint": ">=9",
+    "eslint-config-prettier": ">=10",
+    "eslint-import-resolver-alias": ">=1.1.2",
+    "eslint-import-resolver-node": ">=0.3.9",
+    "eslint-import-resolver-nuxt": ">=1",
+    "eslint-plugin-import": ">=2.30",
+    "eslint-plugin-prettier": ">=5.2",
+    "eslint-plugin-react": ">=7.37",
+    "eslint-plugin-react-hooks": ">=5.2",
+    "eslint-plugin-vue": ">=10",
+    "globals": ">=14",
+    "typescript-eslint": ">=8"
+  },
+  "peerDependenciesMeta": {
+    "eslint-plugin-vue": {
+      "optional": true
+    },
+    "eslint-import-resolver-nuxt": {
+      "optional": true
+    },
+    "eslint-plugin-react": {
+      "optional": true
+    },
+    "eslint-plugin-react-hooks": {
+      "optional": true
+    }
   }
 }

--- a/package.json
+++ b/package.json
@@ -15,18 +15,18 @@
   "author": "dev@web-bee.ru",
   "license": "ISC",
   "devDependencies": {
-    "@typescript-eslint/eslint-plugin": "^3.8.0",
-    "@typescript-eslint/parser": "^3.8.0",
-    "eslint": "^7.23.0",
-    "eslint-config-prettier": "^8.3.0",
+    "@stylistic/eslint-plugin": "^4.2.0",
+    "eslint": "^9.25.0",
+    "eslint-config-prettier": "^10.1.2",
     "eslint-import-resolver-alias": "^1.1.2",
     "eslint-import-resolver-node": "^0.3.4",
     "eslint-import-resolver-nuxt": "^1.0.1",
-    "eslint-plugin-import": "^2.22.0",
-    "eslint-plugin-prettier": "^3.4.0",
-    "eslint-plugin-react": "^7.20.5",
-    "eslint-plugin-react-hooks": "^4.1.2",
-    "eslint-plugin-vue": "^7.9.0",
-    "standard-version": "^9.3.2"
+    "eslint-plugin-import": "^2.31.0",
+    "eslint-plugin-prettier": "^5.2.6",
+    "eslint-plugin-react": "^7.37.5",
+    "eslint-plugin-react-hooks": "^5.2.0",
+    "eslint-plugin-vue": "^10.0.0",
+    "standard-version": "^9.3.2",
+    "typescript-eslint": "^8.31.1"
   }
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "include": ["configs/**/*"],
+  "compilerOptions": {
+    "esModuleInterop": true,
+    "allowJs": true,
+    "declaration": true,
+    "emitDeclarationOnly": true,
+    "outDir": "dist/types",
+    "skipLibCheck": true
+  }
+}

--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -1,0 +1,20 @@
+import { defineConfig } from 'tsup'
+
+export default defineConfig({
+  entry: ['configs/**/*.js'],
+  clean: true,
+  skipNodeModulesBundle: true,
+  format: ['cjs', 'esm'],
+  onSuccess: 'tsc',
+  splitting: false,
+  cjsInterop: true,
+  esbuildOptions: (options) => {
+    // *.cjs конфиги (в dist) имеют экспорт вида module.exports.default что не допустимо для eslint
+    // cjsInterop: true должен решать эту проблему, но походу он не работает
+    if (options.format === 'cjs') {
+      options.footer = {
+        js: 'module.exports = module.exports.default;',
+      }
+    }
+  }
+})


### PR DESCRIPTION
Основные правки:

- Мигрировал старый конфиг на новый flat конфиг.
- Обновил eslint до 9 версии. Также обновил часть зависимостей, чтобы они корректно работали с новой версией, в частности с новым flat конфигом.
- С обновлением eslint обновились и recommended конфиги и сами правила, соответственно, часть правил либо были вообще удалены из плагинов, либо были отключены в новых версиях рекомендуемых конфигов, поэтому выпилил часть старых "off" правил, которые отключали то, что и так было отключено
- Добавил stylistic плагин, так как правила  которые отвечали за стиль кода, были вынесены в отдельный stylistic плагин и были помечены как устаревшие или вообще были удалены в eslint, typescript-eslint
- `@typescript-eslint/ban-types` был выпилен и разделен на несколько правил. Как я понял, судя по комменту: 
`@TODO: Disable only baning {}`, надо было разрешить юзать `{}`, поэтому заменил правило:
`'@typescript-eslint/ban-types': ['off']` 
на правило:
 `'@typescript-eslint/no-empty-object-type': ['off']`